### PR TITLE
Add `/dev/note` endpoint for live testing

### DIFF
--- a/culturemesh/__init__.py
+++ b/culturemesh/__init__.py
@@ -25,6 +25,7 @@ from culturemesh.blueprints.networks.controllers import networks
 from culturemesh.blueprints.events.controllers import events
 from culturemesh.blueprints.posts.controllers import posts
 from culturemesh.blueprints.users.controllers import users
+from culturemesh.blueprints.dev.controllers import dev
 
 app.register_blueprint(user_home, url_prefix='/home')
 app.register_blueprint(search, url_prefix='/search')
@@ -32,3 +33,4 @@ app.register_blueprint(networks, url_prefix='/network')
 app.register_blueprint(events, url_prefix='/event')
 app.register_blueprint(posts, url_prefix='/post')
 app.register_blueprint(users, url_prefix='/u')
+app.register_blueprint(dev, url_prefix='/dev')

--- a/culturemesh/blueprints/dev/controllers.py
+++ b/culturemesh/blueprints/dev/controllers.py
@@ -1,0 +1,7 @@
+from flask import Blueprint, render_template
+
+dev = Blueprint('dev', __name__, template_folder='templates')
+
+@dev.route("/note")
+def get_note():
+    return render_template("note.html")

--- a/culturemesh/blueprints/dev/templates/note.html
+++ b/culturemesh/blueprints/dev/templates/note.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Debugging Note</title>
+</head>
+<body>
+<h1>Debugging Note for Developers</h1>
+<p>This page is for developers to check that the website has updated.</p>
+<h1>Note:</h1>
+<p>Your note here!</p>
+</body>
+</html>

--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -41,4 +41,10 @@ Add unit tests for ``culturemesh/path/to/file.py`` at
 Integration Tests
 -----------------
 
-There are currently no integration tests for CultureMesh FFB.
+There are currently no integration tests for CultureMesh FFB. There are,
+however, tools to make live debugging easier. For example, if you want to check
+that the server has registered code changes and is serving the latest your
+changes, you can use the ``/dev/note`` endpoint. This endpoint serves the
+contents of the template ``note.html``, which you can change to display
+custom text. If that new text is displayed at that endpoint, you know the
+server has updated to reflect your changes.


### PR DESCRIPTION
The server can take time to reflect code changes, and if changes do not
affect the UI, it can be difficult to tell whether the server has
updated. This is especially troublesome when trying many potential fixes
for a bug without knowing that any will work.

To fix this problem, this commit adds a `/dev/note` endpoint that serves
up a custom "note" developers can change whenever they want to check
that the server has updated. This is exposed to users for simplicity
now, but users should never encounter it as there are no links to it
from pages for users. In the future, perhaps debugging features like
this should be authenticated in some way.