### PR TITLE
Set Defaults for about_me and gender

### DIFF
--- a/culturemesh/views.py
+++ b/culturemesh/views.py
@@ -83,6 +83,8 @@ def register():
       'last_name': lastname,
       'email': email,
       'role': '0',
+      'about_me': '',
+      'gender': '',
       'act_code': 'NULL' # TODO: what to do here?
     }
 


### PR DESCRIPTION
When creating a new user, initialize the `about_me` and `gender` fields
as required by the API. This resolves #92.